### PR TITLE
sayln function when outputting config

### DIFF
--- a/src/delivery/delivery_config/mod.rs
+++ b/src/delivery/delivery_config/mod.rs
@@ -133,7 +133,7 @@ impl DeliveryConfig {
         let json_string = format!("{}", json_obj);
         sayln("magenta", "New delivery configuration");
         sayln("magenta", "--------------------------");
-        say("white", &json_string);
+        sayln("white", &json_string);
         try!(f.write_all(json_string.as_bytes()));
         Ok(())
     }


### PR DESCRIPTION
Change from say to sayln function when outputting json for initial config.

current:
```shell
PCB generate: "chef" "generate" "cookbook" ".delivery/build-cookbook" "-g" "/home/testuser/.delivery/cache/generator-cookbooks/pcb"
Git add and commit of build-cookbook
Writing configuration to /home/testuser/Development/deliver-customers-rhel/.delivery/config.json
New delivery configuration
--------------------------
{
  "version": "2",
  "build_cookbook": {
    "name": "build-cookbook",
    "path": ".delivery/build-cookbook"
  },
  "skip_phases": [],
  "build_nodes": {},
  "dependencies": []
}Chef Delivery
```