### PR TITLE
The 'Term' crate raises an error if we try to output a color that the underlying terminal does not support

### DIFF
--- a/src/delivery/utils/say.rs
+++ b/src/delivery/utils/say.rs
@@ -90,7 +90,9 @@ fn say_term(mut t: Box<term::StdoutTerminal>, color: &str, to_say: &str) {
         "white" => term::color::WHITE,
         _ => term::color::WHITE
     };
-    t.fg(color_const).unwrap();
+    if t.supports_color() {
+        t.fg(color_const).unwrap();
+    }
     t.write_all(to_say.as_bytes()).unwrap();
     t.reset().unwrap();
     io::stdout().flush().ok().expect("Could not flush stdout");


### PR DESCRIPTION
Instead of doing that and panicking the thread, we would rather just not set a color

\cc @tylercloke @dmccown @afiune 