### PR TITLE
Display a message when we update the delivery remote.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
-# Copyright 2015 Chef Software, Inc.
-#
-# Author: Jon Anderson (janderson@chef.io)
+##
+## Copyright:: Copyright (c) 2017 Chef Software, Inc.
+## License:: Apache License, Version 2.0
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
 
 RUST_VERSION ?= 1.15.0
 
@@ -13,6 +26,18 @@ CARGO_ENV += DELIV_CLI_VERSION="$(DELIV_CLI_VERSION)"
 CARGO_ENV += DELIV_CLI_GIT_SHA="$(DELIV_CLI_GIT_SHA)"
 CARGO_ENV += RUSTC_VERSION="$(RUSTC_VERSION)"
 CARGO_ENV += DELIV_CLI_TIME="$(DELIV_CLI_TIME)"
+CARGO_ENV += RUST_TEST_TASKS=1
+CARGO_ENV += RUST_BACKTRACE=1
+
+# We need to set some Git variables for cargo and cucumber
+# to consume them. Essentially because we run underneed
+# a few `git commit` commands.
+CARGO_ENV += GIT_COMMITTER_NAME="Chef CI"
+CARGO_ENV += GIT_AUTHER_NAME="Chef CI"
+CARGO_ENV += EMAIL="blackhole@chef.io"
+CUCUMBER_ENV += GIT_COMMITTER_NAME="Chef CI"
+CUCUMBER_ENV += GIT_AUTHER_NAME="Chef CI"
+CUCUMBER_ENV += EMAIL="blackhole@chef.io"
 
 UNAME = $(shell uname)
 
@@ -59,7 +84,7 @@ check:
 	$(MAKE) test
 
 test:
-	RUST_TEST_TASKS=1 RUST_BACKTRACE=1 GIT_COMMITTER_NAME="Chef CI" GIT_AUTHER_NAME="Chef CI"	EMAIL="blackhole@chef.io"	$(CARGO) $(CARGO_OPTS) test
+	$(CARGO) $(CARGO_OPTS) test
 
 travis:
 	export HOME=/home/travis
@@ -76,7 +101,7 @@ travis:
 # Depends on the target/release/delivery executable having been built
 cucumber: release
 	chef exec bundle install
-	GIT_COMMITTER_NAME="Chef CI" GIT_AUTHER_NAME="Chef CI" EMAIL="blackhole@chef.io" chef exec cucumber
+	$(CUCUMBER_ENV) chef exec cucumber
 
 openssl_check:
 	@ls $(OPENSSL_PREFIX) >> /dev/null || \

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -24,4 +24,5 @@ Scenario: Happy Path Checkout
   Then the output should contain "awesome/feature"
   And "git fetch delivery" should be run
   And "git branch --track awesome/feature delivery/_reviews/master/awesome/feature/latest" should be run
+  And "git remote add delivery ssh://user@ent@server.test:8989/ent/org/project" should not be run
   And "git checkout awesome/feature" should be run

--- a/features/init.feature
+++ b/features/init.feature
@@ -60,15 +60,14 @@ Scenario: When creating a delivery backed project when FIPS mode is enables and
           the delivery remote is different from the loaded configuration
   When I set up basic delivery and git configs
   And I successfully run `git remote add delivery fake`
-  And I run `delivery init --fips --fips-git-port 4321` interactively
-  And I type "y"
+  And I run `delivery init --fips --fips-git-port 4321`
   And I successfully run `git remote -v`
   # The address is 127.0.0.1:8080:8080 because the server is running on localhost:8080
   # and the git port is 8080. Not what you'd ever see irl.
-  Then the output should contain "The 'delivery' remote doesn't match with the default configuration loaded from"
+  Then the output should contain "Updating 'delivery' remote with the default configuration loaded from"
   Then the output should contain "current: fake"
   Then the output should contain "update:  ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init"
-  Then the output should contain "Would you like to update it? (y/n):"
+  Then the output should contain "delivery	ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init (fetch)"
 
 Scenario: When creating a delivery backed project that already has a .delivery/build_cookbook directory and .delivery/config.json
   When I already have a .delivery/config.json on disk

--- a/features/init.feature
+++ b/features/init.feature
@@ -50,21 +50,25 @@ Scenario: When creating a delivery backed project and
   When I cd to ".."
   When I am in the "already-created" git repo
   When I set up basic delivery and git configs
-  Then I run `delivery init`
+  Then I successfully run `delivery init`
   Then a delivery project should not be created in delivery
   And a default config.json is created
   And the change has the default generated build_cookbook
   And the exit status should be 0
 
-Scenario: When creating a delivery backed project but
-	  the delivery remote is different.
+Scenario: When creating a delivery backed project when FIPS mode is enables and
+          the delivery remote is different from the loaded configuration
   When I set up basic delivery and git configs
-  When I successfully run `git remote add delivery fake`
-  When I successfully run `delivery init`
-  When I successfully run `git remote -v`
+  And I successfully run `git remote add delivery fake`
+  And I run `delivery init --fips --fips-git-port 4321` interactively
+  And I type "y"
+  And I successfully run `git remote -v`
   # The address is 127.0.0.1:8080:8080 because the server is running on localhost:8080
   # and the git port is 8080. Not what you'd ever see irl.
-  Then the output should contain "ssh://dummy@dummy@127.0.0.1:8080:8080/dummy/dummy/delivery-cli-init (fetch)"
+  Then the output should contain "The 'delivery' remote doesn't match with the default configuration loaded from"
+  Then the output should contain "current: fake"
+  Then the output should contain "update:  ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init"
+  Then the output should contain "Would you like to update it? (y/n):"
 
 Scenario: When creating a delivery backed project that already has a .delivery/build_cookbook directory and .delivery/config.json
   When I already have a .delivery/config.json on disk

--- a/features/job.feature
+++ b/features/job.feature
@@ -28,7 +28,7 @@ Scenario: With all information specified in the configuration file
   """
   And "git clone ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project ." should be run
   And 'git fetch origin _reviews/master/username/feature/branch/1' should be run
-  And 'git remote add delivery ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project' should be run
+  And 'git remote add delivery ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project' should not be run
 
 Scenario: Specifying the patchset branch explicitly
   When I successfully run `delivery job verify syntax --project phoenix_project --for master --change-id 822b0eee-5cfb-4b35-9331-c9bc6b49bdb2 --branch username/feature/branch`
@@ -39,7 +39,7 @@ Scenario: Specifying the patchset branch explicitly
   """
   And "git clone ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project ." should be run
   And 'git fetch origin username/feature/branch' should be run
-  And 'git remote add delivery ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project' should be run
+  And 'git remote add delivery ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project' should not be run
 
 Scenario: A repo that has failing tests
   Given I have a repository with failing tests
@@ -51,7 +51,7 @@ Scenario: A repo that has failing tests
   """
   And "git clone ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project ." should be run
   And 'git fetch origin username/feature/branch' should be run
-  And 'git remote add delivery ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project' should be run
+  And 'git remote add delivery ssh://cukes@skunkworks@delivery.mycompany.com:2828/skunkworks/engineering/phoenix_project' should not be run
 
 Scenario: Executing a local job
   When I run `delivery job verify syntax -l`

--- a/features/review.feature
+++ b/features/review.feature
@@ -52,7 +52,7 @@ Scenario: I want to target a different branch than the pipeline default using
   Then the output should contain "Review for change "
   And the output should not contain "is a cookbook"
   And "git push --porcelain --progress --verbose delivery foo:_for/staging/foo" should be run
-  And "git remote add delivery ssh://user@ent@server.test:8989/ent/org/project" should be run
+  And "git remote add delivery ssh://user@ent@server.test:8989/ent/org/project" should not be run
 
 Scenario: I want to target a different branch than the pipeline default using
           the --pipeline flag.
@@ -94,7 +94,7 @@ Scenario: I run a review on a directory with a different name than
   When I have a feature branch "foo" off of "master"
   And I successfully run `delivery review`
   Then the exit status should be 0
-  And "git remote add delivery ssh://user@ent@server.test:8989/ent/org/special" should be run
+  And "git remote add delivery ssh://user@ent@server.test:8989/ent/org/special" should not be run
 
 Scenario: I'm on the target branch I'm trying to push for review on
 

--- a/src/delivery/command/checkout.rs
+++ b/src/delivery/command/checkout.rs
@@ -18,7 +18,6 @@
 use std;
 use fips;
 use git;
-use project;
 use cli::checkout::CheckoutClapOptions;
 use types::{DeliveryResult, ExitCode};
 use utils::say::{sayln, say};
@@ -32,7 +31,7 @@ pub struct CheckoutCommand<'n> {
 
 impl<'n> Command for CheckoutCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
-        try!(project::ensure_git_remote_up_to_date(&self.config));
+        try!(super::verify_and_repair_git_remote(&self.config));
         try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
         Ok(())
     }

--- a/src/delivery/command/checkout.rs
+++ b/src/delivery/command/checkout.rs
@@ -31,8 +31,10 @@ pub struct CheckoutCommand<'n> {
 
 impl<'n> Command for CheckoutCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
-        try!(super::verify_and_repair_git_remote(&self.config));
-        try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
+        if self.config.fips.unwrap_or(false) {
+            try!(super::verify_and_repair_git_remote(&self.config));
+            try!(fips::setup_and_start_stunnel(&self.config, child_processes));
+        }
         Ok(())
     }
 

--- a/src/delivery/command/clone.rs
+++ b/src/delivery/command/clone.rs
@@ -23,8 +23,7 @@ use types::{DeliveryResult, ExitCode};
 use errors::DeliveryError;
 use errors::Kind::{MissingSshPubKey, CloneFailed, ProjectNotFound, UnauthorizedAction};
 use utils::say::{say, sayln};
-use utils::cwd;
-use utils::path_ext;
+use utils::{cwd, path_ext};
 use http::APIClient;
 use user::User;
 use command::Command;
@@ -103,8 +102,28 @@ impl<'n> Command for CloneCommand<'n> {
             return Err(e)
         }
 
-        try!(git::create_or_update_delivery_remote(&delivery_url,
-                                                   &project_root));
+        try!(git::update_delivery_remote(&delivery_url, &project_root));
+        sayln("success", "Your project was cloned successfully.");
+
+        // Should we autmatically generate a cli.toml inside project?
+        //
+        // We could have the clone comand to write the toml file inside
+        // the project so that any other command that depends on the config
+        // won't complain about it. But if we do that we need to consider:
+        //
+        // a) Should we notify the end-user that they have to add a
+        //    `cli.toml` entry to their `.gitignore`?
+        // b) Or should we just modify it automatically?
+        //    (I wouldn't like this)
+        // c) We could also add it to the chefdk generator.
+        //
+        // If we want to persue this option, uncomment the following lines:
+        //try!(self.config.write_file(&project_root));
+        //let gitignore = read_file(project_root.join(".gitignore"))?;
+        //if gitignore.find("cli.toml").is_none() {
+            //sayln("yellow", "Make sure you have a 'cli.toml' entry in your '.gitignore'");
+        //}
+
         Ok(0)
     }
 }

--- a/src/delivery/command/clone.rs
+++ b/src/delivery/command/clone.rs
@@ -36,7 +36,9 @@ pub struct CloneCommand<'n> {
 
 impl<'n> Command for CloneCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
-        try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
+        if self.config.fips.unwrap_or(false) {
+            try!(fips::setup_and_start_stunnel(&self.config, child_processes));
+        }
         Ok(())
     }
 

--- a/src/delivery/command/diff.rs
+++ b/src/delivery/command/diff.rs
@@ -16,7 +16,6 @@
 //
 
 use std;
-use project;
 use fips;
 use git;
 use cli::diff::DiffClapOptions;
@@ -33,7 +32,7 @@ pub struct DiffCommand<'n> {
 impl<'n> Command for DiffCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
         if !self.options.local {
-            try!(project::ensure_git_remote_up_to_date(&self.config));
+            try!(super::verify_and_repair_git_remote(&self.config));
             try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
         }
 

--- a/src/delivery/command/diff.rs
+++ b/src/delivery/command/diff.rs
@@ -32,8 +32,10 @@ pub struct DiffCommand<'n> {
 impl<'n> Command for DiffCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
         if !self.options.local {
-            try!(super::verify_and_repair_git_remote(&self.config));
-            try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
+            if self.config.fips.unwrap_or(false) {
+                try!(super::verify_and_repair_git_remote(&self.config));
+                try!(fips::setup_and_start_stunnel(&self.config, child_processes));
+            }
         }
 
         Ok(())

--- a/src/delivery/command/init.rs
+++ b/src/delivery/command/init.rs
@@ -46,7 +46,7 @@ pub struct InitCommand<'n> {
 impl<'n> Command for InitCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
         if !self.options.local {
-            try!(project::ensure_git_remote_up_to_date(&self.config));
+            try!(super::verify_and_repair_git_remote(&self.config));
             try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
         }
         Ok(())

--- a/src/delivery/command/init.rs
+++ b/src/delivery/command/init.rs
@@ -46,8 +46,10 @@ pub struct InitCommand<'n> {
 impl<'n> Command for InitCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
         if !self.options.local {
-            try!(super::verify_and_repair_git_remote(&self.config));
-            try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
+            if self.config.fips.unwrap_or(false) {
+                try!(super::verify_and_repair_git_remote(&self.config));
+                try!(fips::setup_and_start_stunnel(&self.config, child_processes));
+            }
         }
         Ok(())
     }

--- a/src/delivery/command/job.rs
+++ b/src/delivery/command/job.rs
@@ -47,7 +47,7 @@ impl<'n> Command for JobCommand<'n> {
         // if that is the case, it should not initialize any project specific
         // command, like the remote.
         if project::project_path().is_ok() && !self.options.local {
-            try!(project::ensure_git_remote_up_to_date(&self.config));
+            try!(super::verify_and_repair_git_remote(&self.config));
         }
 
         if !self.options.local {

--- a/src/delivery/command/mod.rs
+++ b/src/delivery/command/mod.rs
@@ -19,8 +19,8 @@ use std;
 use git;
 use project;
 use utils;
-use utils::say::say;
-use utils::{cwd, read_from_terminal};
+use utils::say::sayln;
+use utils::cwd;
 use types::{DeliveryResult, ExitCode};
 use config::Config;
 
@@ -64,15 +64,12 @@ pub fn verify_and_repair_git_remote(config: &Config) -> DeliveryResult<()> {
         let p_path = project::project_path()?;
         let c_path = Config::dot_delivery_cli_path(&cwd()).expect("Unable to find cli.toml");
         let git_ssh_url = config.delivery_git_ssh_url()?;
-        let msg = &format!("The 'delivery' remote doesn't match with the default \
-                  configuration loaded from {:?}.\n\tcurrent: {}\n\tupdate:  {}\
-                  \n\nWould you like to update it? (y/n): ", c_path,
+        let msg = &format!("Updating 'delivery' remote with the default configuration \
+                  loaded from {:?}.\n\tcurrent: {}\n\tupdate:  {}", c_path,
                   &git::delivery_remote_from_repo(&p_path)?,
                   &git_ssh_url);
-        say("yellow", msg);
-        if read_from_terminal()? == "y" {
-            try!(git::update_delivery_remote(&git_ssh_url, &p_path));
-        }
+        sayln("yellow", msg);
+        try!(git::update_delivery_remote(&git_ssh_url, &p_path));
     }
     Ok(())
 }

--- a/src/delivery/command/pull.rs
+++ b/src/delivery/command/pull.rs
@@ -32,8 +32,10 @@ pub struct PullCommand<'n> {
 
 impl<'n> Command for PullCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
-        try!(super::verify_and_repair_git_remote(&self.config));
-        try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
+        if self.config.fips.unwrap_or(false) {
+            try!(super::verify_and_repair_git_remote(&self.config));
+            try!(fips::setup_and_start_stunnel(&self.config, child_processes));
+        }
         Ok(())
     }
 

--- a/src/delivery/command/pull.rs
+++ b/src/delivery/command/pull.rs
@@ -18,7 +18,6 @@
 use std;
 use fips;
 use git;
-use project;
 use errors;
 use cli::pull::PullClapOptions;
 use types::{DeliveryResult, ExitCode};
@@ -33,7 +32,7 @@ pub struct PullCommand<'n> {
 
 impl<'n> Command for PullCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
-        try!(project::ensure_git_remote_up_to_date(&self.config));
+        try!(super::verify_and_repair_git_remote(&self.config));
         try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
         Ok(())
     }

--- a/src/delivery/command/review.rs
+++ b/src/delivery/command/review.rs
@@ -37,8 +37,10 @@ pub struct ReviewCommand<'n> {
 
 impl<'n> Command for ReviewCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
-        try!(super::verify_and_repair_git_remote(&self.config));
-        try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
+        if self.config.fips.unwrap_or(false) {
+            try!(super::verify_and_repair_git_remote(&self.config));
+            try!(fips::setup_and_start_stunnel(&self.config, child_processes));
+        }
         Ok(())
     }
 

--- a/src/delivery/command/review.rs
+++ b/src/delivery/command/review.rs
@@ -37,7 +37,7 @@ pub struct ReviewCommand<'n> {
 
 impl<'n> Command for ReviewCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
-        try!(project::ensure_git_remote_up_to_date(&self.config));
+        try!(super::verify_and_repair_git_remote(&self.config));
         try!(fips::setup_and_start_stunnel_if_fips_mode(&self.config, child_processes));
         Ok(())
     }

--- a/src/delivery/command/setup.rs
+++ b/src/delivery/command/setup.rs
@@ -17,7 +17,8 @@
 
 use cli::setup::SetupClapOptions;
 use types::{DeliveryResult, ExitCode};
-use utils::say::sayln;
+use utils::say::{say, sayln};
+use utils::path_join_many::PathJoinMany;
 use std::path::PathBuf;
 use config::Config;
 use command::Command;
@@ -31,7 +32,16 @@ pub struct SetupCommand<'n> {
 impl<'n> Command for SetupCommand<'n> {
     fn run(&self) -> DeliveryResult<ExitCode> {
         sayln("green", "Chef Delivery");
-        try!(self.config.write_file(self.config_path));
+
+        let toml_path = self.config_path.join_many(&[".delivery", "cli.toml"]);
+        say("white", "Writing configuration to ");
+        sayln("yellow", &format!("{}", toml_path.display()));
+
+        let pretty_toml = self.config.write_file(self.config_path)?;
+        sayln("magenta", "New configuration");
+        sayln("magenta", "-----------------");
+        say("white", &pretty_toml);
+
         Ok(0)
     }
 }

--- a/src/delivery/git/mod.rs
+++ b/src/delivery/git/mod.rs
@@ -283,9 +283,9 @@ pub fn create_repo(path: &PathBuf) -> Result<(), DeliveryError> {
 // Returns the (Git) delivery remote URL form the specified repository path
 //
 // ex.=> ssh://user@ent@delivery.example.com:8989/ent/organization/foo
-pub fn delivery_remote_from_repo<P>(path: &P) -> DeliveryResult<String>
+pub fn delivery_remote_from_repo<P>(path: P) -> DeliveryResult<String>
         where P: AsRef<Path> {
-    git_command(&["config", "--get", "remote.delivery.url"], path)
+    git_command(&["config", "--get", "remote.delivery.url"], path.as_ref())
         .map(|g| g.stdout.trim().to_string())
         // If there is no 'delivery' remote, return an empty String
         .or(Ok(String::from("")))

--- a/src/delivery/git/mod.rs
+++ b/src/delivery/git/mod.rs
@@ -28,6 +28,7 @@ use std::convert::AsRef;
 use std::error;
 use regex::Regex;
 use project::project_path;
+use types::DeliveryResult;
 
 fn cwd() -> PathBuf {
     env::current_dir().unwrap()
@@ -279,27 +280,38 @@ pub fn create_repo(path: &PathBuf) -> Result<(), DeliveryError> {
     }
 }
 
-pub fn create_or_update_delivery_remote(url: &str, path: &PathBuf) -> Result<bool, DeliveryError> {
-    let result = git_command(&["remote", "add", "delivery", &url], path);
-    match result {
-        Ok(_) => return Ok(true),
-        Err(e) => {
-            match e.detail.clone() {
-                Some(msg) => {
-                    if msg.contains("remote delivery already exists") {
-                        try!(git_command(&["remote", "rm", "delivery"], path));
-                        try!(git_command(&["remote", "add", "delivery", &url], path));
-                        return Ok(false)
-                    } else {
-                        return Err(e)
-                    }
-                },
-                None => {
-                    return Err(e)
-                }
+// Returns the (Git) delivery remote URL form the specified repository path
+//
+// ex.=> ssh://user@ent@delivery.example.com:8989/ent/organization/foo
+pub fn delivery_remote_from_repo<P>(path: &P) -> DeliveryResult<String>
+        where P: AsRef<Path> {
+    git_command(&["config", "--get", "remote.delivery.url"], path)
+        .map(|g| g.stdout.trim().to_string())
+        // If there is no 'delivery' remote, return an empty String
+        .or(Ok(String::from("")))
+}
+
+// Update the (Git) delivery remote
+//
+// Try to add the delivery remote and if it fails adding it, try to remove
+// it first and then add it. This way we ensure we are updating it with the
+// provided URL no mather if it already exists or not.
+pub fn update_delivery_remote<P, S>(url: S, path: P) -> DeliveryResult<()>
+        where P: AsRef<Path>,
+              S: AsRef<str> {
+    let path = path.as_ref();
+    let url  = url.as_ref();
+    git_command(&["remote", "add", "delivery", url], path)
+        .map(|_| ())
+        .or_else(|e| {
+            let msg = e.detail.clone().unwrap_or(String::from(""));
+            if msg.contains("remote delivery already exists") {
+                try!(git_command(&["remote", "rm", "delivery"], path));
+                try!(git_command(&["remote", "add", "delivery", url], path));
+                return Ok(())
             }
-        },
-    }
+            return Err(e)
+    })
 }
 
 pub fn checkout_branch_name(change: &str, patchset: &str) -> String {
@@ -460,7 +472,8 @@ pub fn git_commit(message: &str) -> Result<(), DeliveryError> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ReviewResult, PushResult, PushResultFlag, parse_git_push_output, parse_line_from_remote, check_repo_init};
+    use super::*;
+    use tempdir::TempDir;
     use std::path::PathBuf;
     use std::fs::DirBuilder;
 
@@ -487,6 +500,29 @@ mod tests {
             .recursive(true)
             .create(&full_path).unwrap();
         assert!(check_repo_init(&path).is_ok());
+    }
+
+    #[test]
+    fn test_when_delivery_remote_from_repo_exist() {
+        let tempdir = TempDir::new("repo").ok().expect("Temp repo dir failed");
+        let path = tempdir.path();
+        // Initialize the fake repo
+        assert!(git_command(&["init"], path).is_ok());
+        assert!(git_command(&["remote", "add", "delivery", "awesome"], path).is_ok());
+        let remote_url = delivery_remote_from_repo(&path);
+        // Returns the remote URL, in this case "awesome"
+        assert_eq!(String::from("awesome"), remote_url.unwrap());
+    }
+
+    #[test]
+    fn test_when_delivery_remote_from_repo_not_exist() {
+        let tempdir = TempDir::new("repo").ok().expect("Temp repo dir failed");
+        let path = tempdir.path();
+        // Initialize the fake repo
+        assert!(git_command(&["init"], path).is_ok());
+        let remote_url = delivery_remote_from_repo(&path);
+        // Returns empty string
+        assert_eq!(String::from(""), remote_url.unwrap());
     }
 
     #[test]

--- a/src/delivery/project/mod.rs
+++ b/src/delivery/project/mod.rs
@@ -144,12 +144,16 @@ pub fn create_delivery_project(client: &APIClient, org: &str,
     }
 }
 
-pub fn ensure_git_remote_up_to_date(config: &Config) -> DeliveryResult<()> {
-    try!(git::create_or_update_delivery_remote(&try!(config.delivery_git_ssh_url()),
-                                               &try!(project_path())
-    ));
-    Ok(())
+// Verify if the (Git) delivery remote needs to be updated
+//
+// This method will compare the Git ssh URL generated form the loaded
+// config and the remote that is configured on the local repository
+pub fn verify_git_remote(config: &Config) -> DeliveryResult<bool> {
+    let remote = config.delivery_git_ssh_url()?;
+    let current = git::delivery_remote_from_repo(&project_path()?)?;
+    Ok(remote != current)
 }
+
 
 // Push local content to the Delivery Server if no upstream commits.
 // Returns true if commits pushed, returns false if upstream commits found.

--- a/src/delivery/utils/mod.rs
+++ b/src/delivery/utils/mod.rs
@@ -23,6 +23,7 @@ use std::env;
 use std::process;
 use std::fs::File;
 use std::process::Output as CmdOutput;
+use std::io;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use utils::path_join_many::PathJoinMany;
@@ -69,6 +70,22 @@ pub fn home_dir(to_append: &[&str]) -> Result<PathBuf, DeliveryError>
                               detail: Some(msg) })
        }
    }
+}
+
+// Read from STDIN
+//
+// Useful helper method to ask questions to the end-user
+//
+// Example:
+// ```
+// say("yellow", "How cool is the delivery-cli? [1-10] ");
+// let coolness = utils::read_from_terminal();
+// assert_eq!(coolness, 10);
+// ```
+pub fn read_from_terminal() -> DeliveryResult<String> {
+    let mut buff = String::new();
+    try!(io::stdin().read_line(&mut buff));
+    Ok(buff.trim().to_string())
 }
 
 /// Walk up a file hierarchy searching for `dir/target`.

--- a/src/delivery/utils/mod.rs
+++ b/src/delivery/utils/mod.rs
@@ -79,7 +79,7 @@ pub fn home_dir(to_append: &[&str]) -> Result<PathBuf, DeliveryError>
 // Example:
 // ```
 // say("yellow", "How cool is the delivery-cli? [1-10] ");
-// let coolness = utils::read_from_terminal();
+// let coolness = utils::read_from_terminal()?;
 // assert_eq!(coolness, 10);
 // ```
 pub fn read_from_terminal() -> DeliveryResult<String> {

--- a/src/delivery/utils/mod.rs
+++ b/src/delivery/utils/mod.rs
@@ -215,13 +215,13 @@ pub fn kill_child_processes(child_processes: Vec<process::Child>) -> DeliveryRes
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
+    use utils::test_paths::fixture_file;
     use std::path::PathBuf;
     use std::ffi::OsStr;
 
     #[test]
     fn traverse_up_for_dot_delivery_found() {
-        let p = env::current_dir().unwrap();
+        let p = fixture_file("test_repo");
         let result = walk_tree_for_path(&p, ".delivery");
         assert!(result.is_some());
         assert_eq!(Some(OsStr::new(".delivery")), result.unwrap().file_name());

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,10 +17,10 @@
 
 extern crate regex;
 extern crate clap;
-#[macro_use] extern crate log;
+extern crate log;
 extern crate env_logger;
 extern crate term;
-#[macro_use] extern crate hyper;
+extern crate hyper;
 extern crate delivery;
 extern crate time;
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,8 @@
 extern crate delivery;
-#[macro_use]
 extern crate serde_json;
 extern crate tempdir;
 extern crate mockito;
-#[macro_use] extern crate log;
+extern crate log;
 
 // Thanks, Cargo.
 macro_rules! test {


### PR DESCRIPTION
If we are about to modify something on the current repository, it would be a great UX if we notify the user we are going to do this.

This commit includes:

- delivery git remote verification: Now we verify if the remote is actually up-to-date or not.
- display a message that shows what we have updated and from where we are loading the config.
- [extra] an idea to write the `cli.toml` inside every repository that the user clones, this way we could ensure that we always have the right config within the repository.

Example:
```
Updating 'delivery' remote with the default configuration loaded from "/Users/salimafiune/chef/delivery/organizations/sandbox/.delivery/cli.toml".
   current: ssh://afiune@chef@delivery.example.com:8989/chef/sandbox/foo
   update:  ssh://afiune@chef@localhost:21334/chef/sandbox/foo
```
This change has the following PR https://github.com/chef/delivery-cli/pull/35 on it since we will be using Github from now on. 

Finally, we won't be updating the remote unless FIPS mode is enabled.