### PR TITLE
Verify the 'delivery' remote always on project initialization

### DIFF
--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -26,3 +26,9 @@ Scenario: Happy Path Checkout
   And "git branch --track awesome/feature delivery/_reviews/master/awesome/feature/latest" should be run
   And "git remote add delivery ssh://user@ent@server.test:8989/ent/org/project" should not be run
   And "git checkout awesome/feature" should be run
+
+Scenario: Checkout a change when FIPS mode is enabled
+  When I run `delivery checkout awesome/feature --fips --fips-git-port 1234`
+  Then the output should contain "Updating 'delivery' remote with the default configuration loaded from"
+  And the delivery remote should exist
+  And the output should contain "update:  ssh://user@ent@localhost:1234/ent/org/project"

--- a/features/init.feature
+++ b/features/init.feature
@@ -22,12 +22,14 @@ Scenario: When specifying a local build_cookbook generator
   When I already have a .delivery/config.json on disk
   And a user tries to create a delivery backed project with a custom generator
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And a custom build_cookbook is generated from "local_path"
   And the exit status should be 0
 
 Scenario: When creating a delivery backed project
   When a user creates a delivery backed project
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And a default config.json is created
   And the change has the default generated build_cookbook
   And the exit status should be 0
@@ -37,6 +39,7 @@ Scenario: When creating a delivery backed project
 Scenario: When running delivery review twice it should not fail
   When a user creates a delivery backed project
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And a default config.json is created
   And I set up basic delivery and git configs
   And the change has the default generated build_cookbook
@@ -52,6 +55,7 @@ Scenario: When creating a delivery backed project and
   When I set up basic delivery and git configs
   Then I successfully run `delivery init`
   Then a delivery project should not be created in delivery
+  And the delivery remote should exist
   And a default config.json is created
   And the change has the default generated build_cookbook
   And the exit status should be 0
@@ -64,16 +68,18 @@ Scenario: When creating a delivery backed project when FIPS mode is enables and
   And I successfully run `git remote -v`
   # The address is 127.0.0.1:8080:8080 because the server is running on localhost:8080
   # and the git port is 8080. Not what you'd ever see irl.
-  Then the output should contain "Updating 'delivery' remote with the default configuration loaded from"
-  Then the output should contain "current: fake"
-  Then the output should contain "update:  ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init"
-  Then the output should contain "delivery	ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init (fetch)"
+  Then the delivery remote should exist
+  And the output should contain "Updating 'delivery' remote with the default configuration loaded from"
+  And the output should contain "current: fake"
+  And the output should contain "update:  ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init"
+  And the output should contain "delivery	ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init (fetch)"
 
 Scenario: When creating a delivery backed project that already has a .delivery/build_cookbook directory and .delivery/config.json
   When I already have a .delivery/config.json on disk
   When I successfully run `mkdir .delivery/build_cookbook`
   When a user creates a delivery backed project
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And a default config.json is created
   And the change does not have the default generated build_cookbook
   And the output should contain "Skipping: build cookbook already exists at .delivery/build_cookbook."
@@ -83,15 +89,16 @@ Scenario: When creating a delivery backed project that already has a .delivery/b
 
 Scenario: When creating a delivery backed project that has been git initalized but does not have a master branch
   When I successfully run `rm -rf .git`
-  When I successfully run `git init`
-  When I run `delivery init`
-  And the output should contain "A master branch does not exist locally."
+  And I successfully run `git init`
+  And I run `delivery init`
+  Then the output should contain "A master branch does not exist locally."
   And the exit status should be 1
 
 Scenario: When creating a delivery backed project that already has a .delivery/config.json directory and no custom config is requested
   When I already have a .delivery/config.json on disk
-  When a user creates a delivery backed project
+  And a user creates a delivery backed project
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And a change to the delivery config is not comitted
   And the change has the default generated build_cookbook
   And the exit status should be 0
@@ -101,6 +108,7 @@ Scenario: When creating a delivery backed project that already has a .delivery/c
 Scenario: When creating a bitbucket backed project
   When a user creates a bitbucket backed project
   Then a bitbucket project is created in delivery
+  And the delivery remote should exist
   And a default config.json is created
   And the change has the default generated build_cookbook
   And the exit status should be 0
@@ -110,6 +118,7 @@ Scenario: When creating a bitbucket backed project
 Scenario: When creating a github backed project
   When a user creates a github backed project
   Then a github project is created in delivery
+  And the delivery remote should exist
   And a default config.json is created
   And the change has the default generated build_cookbook
   And the exit status should be 0
@@ -118,9 +127,10 @@ Scenario: When creating a github backed project
 
 Scenario: When creating a github backed project with an initial origin remote set
   When I successfully run `git init`
-  When I successfully run `git remote add origin fake`
-  When a user creates a github backed project
+  And I successfully run `git remote add origin fake`
+  And a user creates a github backed project
   Then a github project is created in delivery
+  And the delivery remote should exist
   And a default config.json is created
   And the change has the default generated build_cookbook
   And the exit status should be 0
@@ -148,6 +158,7 @@ Scenario: When the directory name does not match the repo-name but I still want 
   When I run `delivery init --github chef --repo-name not-the-right-repo` interactively
   And I type "y"
   Then a github project is created in delivery
+  And the delivery remote should exist
   And a default config.json is created
   And the change has the default generated build_cookbook
   And I should be checked out to a feature branch named "initialize-delivery-pipeline"
@@ -158,8 +169,9 @@ Scenario: When the directory name does not match the repo-name but I still want 
 
 Scenario: When skipping the build_cookbook generator
   When I already have a .delivery/config.json on disk
-  When a user creates a delivery backed project with option "--skip-build-cookbook"
+  And a user creates a delivery backed project with option "--skip-build-cookbook"
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And no build_cookbook is generated
   And the exit status should be 0
   And I should be checked out to a feature branch named "initialize-delivery-pipeline"
@@ -167,9 +179,10 @@ Scenario: When skipping the build_cookbook generator
 
 Scenario: When specifying a GitRepo Url for the build_cookbook generator
   When a custom build cookbook is already downloaded in the cache
-  When I already have a .delivery/config.json on disk
-  When a user creates a delivery backed project with option "--generator https://github.com/afiune/test-generator"
+  And I already have a .delivery/config.json on disk
+  And a user creates a delivery backed project with option "--generator https://github.com/afiune/test-generator"
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And a custom build_cookbook is generated from "git_repo"
   And the exit status should be 0
   And I should be checked out to a feature branch named "add-delivery-config"
@@ -180,12 +193,14 @@ Scenario: When specifying a local build_cookbook generator with no config
   When I have a custom generator cookbook with no config generator
   When a custom config
   Then a user tries to create a delivery backed project with a custom config and custom generator
+  And the delivery remote should exist
   And the output should contain "Your new Delivery project is ready"
   And the exit status should be 0
 
 Scenario: When providing a custom config.json
   When a user creates a project with a custom config.json
   Then a custom config is generated
+  And the delivery remote should exist
   And the change has the default generated build_cookbook
   And a change configuring a custom delivery is created
   And the exit status should be 0
@@ -197,6 +212,7 @@ Scenario: When specifying both, generator and custom config we will expect
           and then the custom config provided would be overwritten
   When a user creates a project with both a custom generator and custom config
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And both a custom build_cookbook and custom config is generated
   And the change has the default generated build_cookbook
   And the exit status should be 0
@@ -216,6 +232,7 @@ Scenario: When creating a delivery backed project for a pipeline
   When I set up basic delivery and git configs
   And I successfully run `git checkout -b awesome`
   Then I run `delivery init --for awesome`
+  And the delivery remote should exist
   And the output should match /pushing local commits from branch awesome/
   And the exit status should be 0
 
@@ -225,6 +242,7 @@ Scenario: When creating a delivery backed project for a pipeline using --pipelin
   When I set up basic delivery and git configs
   And I successfully run `git checkout -b awesome`
   Then I run `delivery init --pipeline awesome`
+  And the delivery remote should exist
   And the output should match /pushing local commits from branch awesome/
   And the exit status should be 0
 
@@ -242,6 +260,7 @@ Scenario: When initializing a project that already have a custom config
   When I have a config where the build_cookbook comes from Supermarket
   When a user creates a delivery backed project
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And the change does not have the default generated build_cookbook
   And the output should contain "Skipping: build cookbook doesn't need to be generated locally."
   And the exit status should be 0
@@ -260,6 +279,7 @@ Scenario: When initializing a project that already have a custom config
   When I have already a custom config
   When a user creates a delivery backed project
   Then a delivery project is created in delivery
+  And the delivery remote should exist
   And the change has a generated build_cookbook called ".delivery/build_cookbook"
   And the output should contain "Build cookbook generated at .delivery/build_cookbook."
   And the exit status should be 0

--- a/features/init.feature
+++ b/features/init.feature
@@ -60,20 +60,6 @@ Scenario: When creating a delivery backed project and
   And the change has the default generated build_cookbook
   And the exit status should be 0
 
-Scenario: When creating a delivery backed project when FIPS mode is enables and
-          the delivery remote is different from the loaded configuration
-  When I set up basic delivery and git configs
-  And I successfully run `git remote add delivery fake`
-  And I run `delivery init --fips --fips-git-port 4321`
-  And I successfully run `git remote -v`
-  # The address is 127.0.0.1:8080:8080 because the server is running on localhost:8080
-  # and the git port is 8080. Not what you'd ever see irl.
-  Then the delivery remote should exist
-  And the output should contain "Updating 'delivery' remote with the default configuration loaded from"
-  And the output should contain "current: fake"
-  And the output should contain "update:  ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init"
-  And the output should contain "delivery	ssh://dummy@dummy@localhost:4321/dummy/dummy/delivery-cli-init (fetch)"
-
 Scenario: When creating a delivery backed project that already has a .delivery/build_cookbook directory and .delivery/config.json
   When I already have a .delivery/config.json on disk
   When I successfully run `mkdir .delivery/build_cookbook`

--- a/features/review.feature
+++ b/features/review.feature
@@ -262,3 +262,15 @@ Scenario: Review with a V1 config
   Then the output should contain "Review for change "
   And the output should not contain "is a cookbook"
   And "git push --porcelain --progress --verbose delivery foo:_for/master/foo" should be run
+
+Scenario: Review a change that has FIPS mode enabled and has
+          a fake delivery git remote configured.
+
+  When I have a feature branch "foo" off of "master"
+  And I checkout the "foo" branch
+  And I successfully run `git remote add delivery fake`
+  And I run `delivery review --fips --fips-git-port 1234`
+  Then the output should contain "Updating 'delivery' remote with the default configuration loaded from"
+  And the delivery remote should exist
+  And the output should contain "current: fake"
+  And the output should contain "update:  ssh://user@ent@localhost:1234/ent/org/project"

--- a/features/support/steps.rb
+++ b/features/support/steps.rb
@@ -236,6 +236,10 @@ Given(/^a user tries to create a delivery backed project with a custom config an
   step %(I run `delivery init -c ../my_custom_config.json --generator #{tmp_expanded_path}/test-generator`)
 end
 
+Given (/^the delivery remote should exist$/) do
+  step %(I successfully run `git config --get remote.delivery.url`)
+end
+
 Given(/^a delivery project is created in delivery$/) do
   step %(the output should match /Delivery project named.*was created/)
 end

--- a/src/delivery/command/init.rs
+++ b/src/delivery/command/init.rs
@@ -47,7 +47,6 @@ impl<'n> Command for InitCommand<'n> {
     fn setup(&self, child_processes: &mut Vec<std::process::Child>) -> DeliveryResult<()> {
         if !self.options.local {
             if self.config.fips.unwrap_or(false) {
-                try!(super::verify_and_repair_git_remote(&self.config));
                 try!(fips::setup_and_start_stunnel(&self.config, child_processes));
             }
         }
@@ -243,6 +242,7 @@ fn create_on_server(config: &Config,
                                              created.", fancy_kind, proj));
                 }
             }
+            try!(create_or_update_git_remote(config));
             try!(push_project_content_to_delivery(&pipe));
         },
         // If the user isn't using an scp, just delivery itself.
@@ -255,6 +255,7 @@ fn create_on_server(config: &Config,
                 sayln("white",
                       &format!("  Skipping: Delivery project named {} already exists.", proj));
             }
+            try!(create_or_update_git_remote(config));
             try!(push_project_content_to_delivery(&pipe));
             try!(create_delivery_pipeline(&client, &org, &proj, &pipe));
         }
@@ -284,6 +285,22 @@ fn verify_config_get_build_cookbook_path<P>(p_path: P) -> DeliveryResult<Option<
     }
     // Getting here means that there is no config.json. Provide the default path.
     Ok(Some(PathBuf::from(".delivery/build_cookbook")))
+}
+
+// Create or update the delivery git remote
+pub fn create_or_update_git_remote(config: &Config) -> DeliveryResult<()> {
+    sayln("cyan", "Setting up the 'delivery' git remote...");
+    if project::verify_git_remote(config)? {
+        let p_path = project::project_path()?;
+        let git_ssh_url = config.delivery_git_ssh_url()?;
+        try!(git::update_delivery_remote(&git_ssh_url, &p_path));
+        sayln("green", &format!("  The delivery git remote has been configured \
+                                 to '{}'.", &git_ssh_url));
+    } else {
+        sayln("white", &format!("  Skipping: The delivery git remote already \
+                                 exists and it is up-to-date."));
+    }
+    Ok(())
 }
 
 // Push content to Delivery if no upstream commits.

--- a/src/delivery/command/mod.rs
+++ b/src/delivery/command/mod.rs
@@ -60,7 +60,7 @@ pub trait Command: Sized {
 // Once you have added the method, you can just call it with `super::foo()` from
 // within any command. (don't forget to make it public)
 pub fn verify_and_repair_git_remote(config: &Config) -> DeliveryResult<()> {
-    if project::verify_git_remote(config)? {
+    if !project::git_remote_up_to_date(config)? {
         let p_path = project::project_path()?;
         let c_path = Config::dot_delivery_cli_path(&cwd()).expect("Unable to find cli.toml");
         let git_ssh_url = config.delivery_git_ssh_url()?;

--- a/src/delivery/project/mod.rs
+++ b/src/delivery/project/mod.rs
@@ -146,12 +146,12 @@ pub fn create_delivery_project(client: &APIClient, org: &str,
 
 // Verify if the (Git) delivery remote needs to be updated
 //
-// This method will compare the Git ssh URL generated form the loaded
+// This method will compare the Git ssh URL generated from the loaded
 // config and the remote that is configured on the local repository
-pub fn verify_git_remote(config: &Config) -> DeliveryResult<bool> {
+pub fn git_remote_up_to_date(config: &Config) -> DeliveryResult<bool> {
     let remote = config.delivery_git_ssh_url()?;
     let current = git::delivery_remote_from_repo(&project_path()?)?;
-    Ok(remote != current)
+    Ok(remote == current)
 }
 
 


### PR DESCRIPTION
When we are initializing the project we must always verify that the
remote is up-to-date since we are actually configuring the project on
the Automate Server.

This PR includes the following changes:

- Adding a new section to add/verify/update the delivery git remote.
- Removing the remote verification from the `Command::setup` fun since we don't need it twice! :smile:
- Added extra cucumber tests for FIPS and also to verify the 'delivery' git remote always exists and we don't miss this again.

cc/ @chef/pool-team 