### PR TITLE
[MSYS-729]: SSH prompt fix windows

### DIFF
--- a/src/delivery/git/mod.rs
+++ b/src/delivery/git/mod.rs
@@ -109,12 +109,11 @@ pub fn git_command<P>(args: &[&str], c: &P) -> Result<GitResult, DeliveryError>
       let cmd_args = args.join(" ");
       let command_ars = &[ &[agent_setup, &cmd_args, agent_kill].join(" ") ];
       command.args(command_ars);
+      command.stderr(Stdio::inherit());
     } else {
       command.args(args);
     }
-
     command.current_dir(cwd);
-    command.stderr(Stdio::inherit());
     debug!("Git command: {:?}", command);
     let output = match command.output() {
         Ok(o) => o,

--- a/src/delivery/git/mod.rs
+++ b/src/delivery/git/mod.rs
@@ -17,7 +17,7 @@
 
 pub use errors;
 
-use std::process::Command;
+use std::process::{Command, Stdio};
 use utils::say::{say, sayln, Spinner};
 use utils::path_ext::{is_dir};
 use utils::{cmd_success_or_err, find_command};
@@ -96,8 +96,25 @@ pub fn git_command<P>(args: &[&str], c: &P) -> Result<GitResult, DeliveryError>
         None => return Err(DeliveryError{ kind: Kind::FailedToExecute, detail: Some("git executable not found".to_owned())}),
     };
     let mut command = Command::new(command_path);
-    command.args(args);
+
+    // SSH Agent is required on windows Hence,
+    // Rebuilding the command in a way; that 
+    // Invoke an agent; Run the SSH Command and kill the agent then and there
+    // Pattern: \embedded\git\bash -c 'eval `ssh-agent` && ssh-add && <COMMAND> ; ssh-agent -k'
+    // TODO: Check for SSH type authencation may be required
+    if cfg!(target_os = "windows"){
+      command.arg("-c");
+      let agent_setup = "eval `ssh-agent` && ssh-add && git";
+      let agent_kill = "; ssh-agent -k";
+      let cmd_args = args.join(" ");
+      let command_ars = &[ &[agent_setup, &cmd_args, agent_kill].join(" ") ];
+      command.args(command_ars);
+    } else {
+      command.args(args);
+    }
+
     command.current_dir(cwd);
+    command.stderr(Stdio::inherit());
     debug!("Git command: {:?}", command);
     let output = match command.output() {
         Ok(o) => o,

--- a/src/delivery/utils/windows.rs
+++ b/src/delivery/utils/windows.rs
@@ -88,6 +88,17 @@ pub fn find_command(command: &str) -> Option<PathBuf> {
     if candidate.is_absolute() && candidate.is_file() {
         return Some(candidate);
     }
+
+    // For SSH based authentication, If git execution is required, 
+    // use the bash embedded in git\bin
+    // TODO: Check for SSH type authencation required
+    if command == "git" {
+        let exe_path = env::current_exe().unwrap();
+        let parent_path = exe_path.parent().unwrap();
+        let command_path = parent_path.to_path_buf().join("..\\embedded\\git\\bin\\bash");
+        return Some(command_path);
+    }
+
     // Find the command by checking each entry in `PATH`. If we still can't find it,
     // give up and return `None`.
     if let Some(paths) = env::var_os("PATH") {


### PR DESCRIPTION
Fix for SSH Prompt includes following changes:
1: To display the passphrase prompt, we need to use Stdio (Stdio::inherit())
2: On windows we are required to use SSH agent, hence we rebuild the command surrounded with SSH agent's creation and deletion; Then only the entered passphrase is significant

Signed-off-by: Nimesh Patni <nimesh.patni@msystechnologies.com>