### PR TITLE
Fix tests in master

### DIFF
--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -235,8 +235,8 @@ test!(job_verify_lint_with_public_supermarket_config {
     setup_change(&local_project.path(), "rust/test", "freaky");
     let mut command = delivery_verify_command(&job_root.path());
     assert_command_failed(&mut command, &local_project.path());
-    assert!(job_root.path().join_many(&["chef", "cookbooks", "httpd"]).is_dir());
-    assert!(job_root.path().join_many(&["chef", "cookbooks", "httpd", "templates", "default", "magic.erb"]).is_file());
+    assert!(job_root.path().join_many(&["chef", "cookbooks", "apache2"]).is_dir());
+    assert!(job_root.path().join_many(&["chef", "cookbooks", "apache2", "templates", "default", "web_app.conf.erb"]).is_file());
 });
 
 // TODO: This test requires internet access...

--- a/tests/fixtures/public_supermarket_config.json
+++ b/tests/fixtures/public_supermarket_config.json
@@ -1,7 +1,7 @@
 {
     "version": "2",
     "build_cookbook": {
-      "name": "httpd",
+      "name": "apache2",
       "supermarket": "true"
     },
     "build_nodes": {


### PR DESCRIPTION
There was a deprecation of the httpd cookbook that we were using for
testing the public supermarket, this change is fixing the tests in
master by using now apache2 instead.

Signed-off-by: Salim Afiune <afiune@chef.io>