### PR TITLE
Add a2-mode option to any command that takes --server

### DIFF
--- a/features/api.feature
+++ b/features/api.feature
@@ -1,9 +1,20 @@
 Feature: api
-
+@api
 Scenario: make a basic call
   Given a dummy api-tokens file
   And a dummy Delivery API server
   When I successfully run `delivery api get 'orgs' --server=localhost --api-port=8080 --ent=dummy --user=link`
+  Then the output should contain:
+    """
+      "orgs": [
+        "dummy"
+      ]
+    """
+
+Scenario: make a basic call with a2_mode
+  Given a dummy api-tokens file
+  And a dummy A2 Workflow API server
+  When I successfully run `delivery api get 'orgs' --server=localhost --api-port=8080 --ent=dummy --user=link --a2-mode`
   Then the output should contain:
     """
       "orgs": [

--- a/features/clone.feature
+++ b/features/clone.feature
@@ -36,6 +36,11 @@ Scenario: With all information specified in the configuration file, but overridi
   Then "git clone ssh://cukes@skunkworks@delivery-acceptance.mycompany.com:8989/skunkworks/engineering/phoenix_project phoenix_project" should be run
   And "git remote add delivery ssh://cukes@skunkworks@delivery-acceptance.mycompany.com:8989/skunkworks/engineering/phoenix_project" should be run
 
+Scenario: With all information specified in the configuration file, but with a2 mode
+  When I successfully run `delivery clone phoenix_project --a2-mode`
+  Then "git clone ssh://cukes@skunkworks@delivery.mycompany.com:8989/skunkworks/engineering/phoenix_project phoenix_project" should be run
+  And "git remote add delivery ssh://cukes@skunkworks@delivery.mycompany.com:8989/skunkworks/engineering/phoenix_project" should be run
+
 Scenario: With no configuration file and no arguments provided
   Given I remove the file ".delivery/cli.toml"
   When I run `delivery clone phoenix_project`

--- a/src/delivery/cli/api.rs
+++ b/src/delivery/cli/api.rs
@@ -15,8 +15,8 @@
 // limitations under the License.
 //
 use clap::{App, Arg, ArgMatches, SubCommand};
+use cli::arguments::{api_port_arg, config_path_arg, u_e_s_o_args, a2_mode_arg, value_of};
 use cli::Options;
-use cli::arguments::{api_port_arg, config_path_arg, u_e_s_o_args, value_of};
 use config::Config;
 use types::DeliveryResult;
 
@@ -31,6 +31,7 @@ pub struct ApiClapOptions<'n> {
     pub api_port: &'n str,
     pub ent: &'n str,
     pub user: &'n str,
+    pub a2_mode: bool,
 }
 
 impl<'n> Default for ApiClapOptions<'n> {
@@ -43,6 +44,7 @@ impl<'n> Default for ApiClapOptions<'n> {
             api_port: "",
             ent: "",
             user: "",
+            a2_mode: false,
         }
     }
 }
@@ -56,6 +58,7 @@ impl<'n> ApiClapOptions<'n> {
             api_port: value_of(&matches, "api-port"),
             ent: value_of(&matches, "ent"),
             user: value_of(&matches, "user"),
+            a2_mode: matches.is_present("a2-mode"),
         }
     }
 }
@@ -66,7 +69,8 @@ impl<'n> Options for ApiClapOptions<'n> {
             .set_user(&self.user)
             .set_server(&self.server)
             .set_api_port(&self.api_port)
-            .set_enterprise(&self.ent);
+            .set_enterprise(&self.ent)
+            .set_a2_mode(self.a2_mode);
         Ok(new_config)
     }
 }
@@ -93,4 +97,5 @@ pub fn clap_subcommand<'c>() -> App<'c, 'c> {
                 .use_delimiter(false),
         )
         .args(&u_e_s_o_args())
+        .args(&vec![a2_mode_arg()])
 }

--- a/src/delivery/cli/clone.rs
+++ b/src/delivery/cli/clone.rs
@@ -15,8 +15,8 @@
 // limitations under the License.
 //
 use clap::{App, ArgMatches, SubCommand};
+use cli::arguments::{project_specific_args, u_e_s_o_args, a2_mode_arg, value_of};
 use cli::Options;
-use cli::arguments::{project_specific_args, u_e_s_o_args, value_of};
 use config::Config;
 use fips;
 use project;
@@ -35,6 +35,7 @@ pub struct CloneClapOptions<'n> {
     pub fips: bool,
     pub fips_git_port: &'n str,
     pub fips_custom_cert_filename: &'n str,
+    pub a2_mode: bool,
 }
 impl<'n> Default for CloneClapOptions<'n> {
     fn default() -> Self {
@@ -48,6 +49,7 @@ impl<'n> Default for CloneClapOptions<'n> {
             fips: false,
             fips_git_port: "",
             fips_custom_cert_filename: "",
+            a2_mode: false,
         }
     }
 }
@@ -64,6 +66,7 @@ impl<'n> CloneClapOptions<'n> {
             fips: matches.is_present("fips"),
             fips_git_port: value_of(&matches, "fips-git-port"),
             fips_custom_cert_filename: value_of(&matches, "fips-custom-cert-filename"),
+            a2_mode: matches.is_present("a2-mode"),
         }
     }
 }
@@ -75,8 +78,8 @@ impl<'n> Options for CloneClapOptions<'n> {
             .set_server(&self.server)
             .set_enterprise(&self.ent)
             .set_organization(&self.org)
-            .set_project(&self.project);
-
+            .set_project(&self.project)
+            .set_a2_mode(self.a2_mode);
         if new_config.project.is_none() {
             new_config.project = project::project_from_cwd().ok();
         }
@@ -100,4 +103,5 @@ pub fn clap_subcommand<'c>() -> App<'c, 'c> {
         )
         .args(&u_e_s_o_args())
         .args(&project_specific_args())
+        .args(&vec![a2_mode_arg()])
 }

--- a/src/delivery/cli/init.rs
+++ b/src/delivery/cli/init.rs
@@ -15,9 +15,11 @@
 // limitations under the License.
 //
 use clap::{App, ArgMatches, SubCommand};
+use cli::arguments::{
+    config_path_arg, config_project_arg, local_arg, no_open_arg, pipeline_arg, project_arg,
+    project_specific_args, scp_args, u_e_s_o_args, a2_mode_arg, value_of,
+};
 use cli::Options;
-use cli::arguments::{config_path_arg, config_project_arg, local_arg, no_open_arg, pipeline_arg,
-                     project_arg, project_specific_args, scp_args, u_e_s_o_args, value_of};
 use config::Config;
 use fips;
 use project;
@@ -45,6 +47,7 @@ pub struct InitClapOptions<'n> {
     pub fips: bool,
     pub fips_git_port: &'n str,
     pub fips_custom_cert_filename: &'n str,
+    pub a2_mode: bool,
 }
 
 impl<'n> Default for InitClapOptions<'n> {
@@ -68,6 +71,7 @@ impl<'n> Default for InitClapOptions<'n> {
             fips: false,
             fips_git_port: "",
             fips_custom_cert_filename: "",
+            a2_mode: false,
         }
     }
 }
@@ -93,6 +97,7 @@ impl<'n> InitClapOptions<'n> {
             fips: matches.is_present("fips"),
             fips_git_port: value_of(&matches, "fips-git-port"),
             fips_custom_cert_filename: value_of(&matches, "fips-custom-cert-filename"),
+            a2_mode: matches.is_present("a2-mode"),
         }
     }
 }
@@ -109,6 +114,7 @@ impl<'n> Options for InitClapOptions<'n> {
             .set_project(&project)
             .set_pipeline(&self.pipeline)
             .set_generator(&self.generator)
+            .set_a2_mode(self.a2_mode)
             .set_config_json(&self.config_json);
 
         fips::merge_fips_options_and_config(
@@ -142,4 +148,5 @@ pub fn clap_subcommand<'c>() -> App<'c, 'c> {
         .args(&scp_args())
         .args(&pipeline_arg())
         .args(&project_specific_args())
+        .args(&vec![a2_mode_arg()])
 }

--- a/src/delivery/cli/job.rs
+++ b/src/delivery/cli/job.rs
@@ -16,9 +16,11 @@
 //
 
 use clap::{App, Arg, ArgMatches, SubCommand};
+use cli::arguments::{
+    a2_mode_arg, local_arg, patchset_arg, pipeline_arg, project_arg, project_specific_args,
+    u_e_s_o_args, value_of,
+};
 use cli::Options;
-use cli::arguments::{local_arg, patchset_arg, pipeline_arg, project_arg, project_specific_args,
-                     u_e_s_o_args, a2_mode_arg, value_of};
 use config::Config;
 use fips;
 use project;
@@ -166,5 +168,5 @@ pub fn clap_subcommand<'c>() -> App<'c, 'c> {
         .args(&u_e_s_o_args())
         .args(&pipeline_arg())
         .args(&project_specific_args())
-		.args(&vec![a2_mode_arg()])
+        .args(&vec![a2_mode_arg()])
 }

--- a/src/delivery/cli/setup.rs
+++ b/src/delivery/cli/setup.rs
@@ -15,8 +15,10 @@
 // limitations under the License.
 //
 use clap::{App, ArgMatches, SubCommand};
+use cli::arguments::{
+    a2_mode_arg, config_path_arg, pipeline_arg, project_arg, u_e_s_o_args, value_of,
+};
 use cli::Options;
-use cli::arguments::{config_path_arg, pipeline_arg, project_arg, u_e_s_o_args, a2_mode_arg, value_of};
 use config::Config;
 use types::DeliveryResult;
 
@@ -31,7 +33,7 @@ pub struct SetupClapOptions<'n> {
     pub path: &'n str,
     pub pipeline: &'n str,
     pub project: &'n str,
-    pub a2_mode: bool
+    pub a2_mode: bool,
 }
 
 impl<'n> Default for SetupClapOptions<'n> {
@@ -77,7 +79,7 @@ impl<'n> Options for SetupClapOptions<'n> {
         // A2 mode requires SAML right now
         if self.a2_mode {
             new_config.saml = Some(true)
-        }        
+        }
         Ok(new_config)
     }
 }

--- a/src/delivery/cli/token.rs
+++ b/src/delivery/cli/token.rs
@@ -15,8 +15,8 @@
 // limitations under the License.
 //
 use clap::{App, Arg, ArgMatches, SubCommand};
+use cli::arguments::{api_port_arg, u_e_s_o_args, a2_mode_arg, value_of};
 use cli::Options;
-use cli::arguments::{api_port_arg, u_e_s_o_args, value_of};
 use config::Config;
 use types::DeliveryResult;
 
@@ -32,7 +32,9 @@ pub struct TokenClapOptions<'n> {
     pub raw: bool,
     // if None, use what the server tells us on its /e/<ent>/saml/enabled endpoint
     pub saml: Option<bool>,
+    pub a2_mode: bool,
 }
+
 impl<'n> Default for TokenClapOptions<'n> {
     fn default() -> Self {
         TokenClapOptions {
@@ -43,6 +45,7 @@ impl<'n> Default for TokenClapOptions<'n> {
             verify: false,
             raw: false,
             saml: None,
+            a2_mode: false,
         }
     }
 }
@@ -61,6 +64,7 @@ impl<'n> TokenClapOptions<'n> {
                 "false" => Some(false),
                 _ => None,
             },
+            a2_mode: matches.is_present("a2-mode"),
         }
     }
 }
@@ -76,7 +80,10 @@ impl<'n> Options for TokenClapOptions<'n> {
         if self.saml.is_some() {
             new_config.saml = self.saml;
         }
-
+        // A2 mode requires SAML right now
+        if self.a2_mode {
+            new_config.saml = Some(true)
+        }
         Ok(new_config)
     }
 }
@@ -91,4 +98,5 @@ pub fn clap_subcommand<'c>() -> App<'c, 'c> {
             "--verify 'Verify the Token has expired'",
             "--saml=[true/false] 'Use SAML authentication (overrides Delivery server)'"
         ])
+        .args(&vec![a2_mode_arg()])
 }


### PR DESCRIPTION
Based on PR #60; rebase and merge after that goes in.

For consistency we should have the a2-mode flag available when we
have a command that lets you override server, since it's principal
function is to modify the resource that formed using the server
argument.

I wrestled with forcing the saml-mode check in all cases, but in the
end decided that wasn't necessary because the saml mode option may not
be appropriate in all cases. It's worth reviewing that again for
sanity.

Signed-off-by: Mark Anderson <mark@chef.io>