### PR TITLE
Increase timeout on cucumber tests

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,6 +1,7 @@
 steps:
 
   - label: cucumber_tests_stable
+    timeout_in_minutes: 20
     commands:
       - . /opt/asdf/asdf.sh
       - useradd dbuild


### PR DESCRIPTION
The cucumber tests take around 15 minutes; a 10 minute timeout isn't enough.

Signed-off-by: Mark Anderson <mark@chef.io>