### PR TITLE
Expeditor fixes

### DIFF
--- a/.expeditor/setup_rust
+++ b/.expeditor/setup_rust
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+asdf plugin-add rust
+asdf install rust $1
+asdf global rust $1

--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -5,7 +5,7 @@ steps:
     commands:
       - . /opt/asdf/asdf.sh
       - useradd dbuild
-      - asdf global rust stable
+      - .expeditor/setup_rust stable
       - make cucumber
     env:
       - CUCUMBER_TESTS: 1
@@ -18,7 +18,7 @@ steps:
       - . /opt/asdf/asdf.sh
       - eval "$(/opt/chefdk/bin/chef shell-init bash)"
       - useradd dbuild
-      - asdf global rust stable
+      - .expeditor/setup_rust stable
       - make test
     env:
       - CARGO_TESTS_STABLE: 1
@@ -31,7 +31,7 @@ steps:
       - . /opt/asdf/asdf.sh
       - eval "$(/opt/chefdk/bin/chef shell-init bash)"
       - useradd dbuild
-      - asdf global rust beta
+      - .expeditor/setup_rust beta
       - make test
     env:
       - CARGO_TESTS_BETA: 1
@@ -44,7 +44,7 @@ steps:
       - . /opt/asdf/asdf.sh
       - eval "$(/opt/chefdk/bin/chef shell-init bash)"
       - useradd dbuild
-      - asdf global rust 1.26.0
+      - .expeditor/setup_rust 1.32.0
       - make test
     env:
       - CARGO_TESTS_DEFINED: 1

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -236,7 +236,7 @@ test!(job_verify_lint_with_public_supermarket_config {
     let mut command = delivery_verify_command(&job_root.path());
     assert_command_failed(&mut command, &local_project.path());
     assert!(job_root.path().join_many(&["chef", "cookbooks", "apache2"]).is_dir());
-    assert!(job_root.path().join_many(&["chef", "cookbooks", "apache2", "templates", "default", "web_app.conf.erb"]).is_file());
+    assert!(job_root.path().join_many(&["chef", "cookbooks", "apache2", "templates", "default-site.conf.erb"]).is_file());
 });
 
 // TODO: This test requires internet access...


### PR DESCRIPTION

## Description
Fix expeditor tests.

1) Install rust asdf plugin and install rust before setting it to global
2) Fix a test regression. 

Signed-off-by: Mark Anderson <mark@chef.io>
